### PR TITLE
dockerfile loads blawx from local for dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ RUN git clone https://github.com/JanWielemaker/sCASP.git && \
 	cd sCASP && \
 	swipl -g "pack_install('.',[interactive(false)])" -t halt
 
-RUN git clone https://github.com/Lexpedite/blawx blawx && \
-    cd blawx/blawx/static/blawx && \
+ADD . blawx
+
+RUN cd blawx/blawx/static/blawx && \
     git clone https://github.com/google/blockly blockly
 
 RUN pip3 install -r blawx/blawx/requirements.txt


### PR DESCRIPTION
The dockerfile was pulling blawx from the github repository, which meant that if you did a rebuild and run while doing dev work it ignored your changes. Changed it so that the Dockerfile adds the local instance of blawx rather than git cloning it.