### PR TITLE
Fix import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ As of v0.2-alpha, this project is attempting to adhere to [Semantic Versioning](
 While alpha, however, any version may include breaking changes that may not be specifically noted as such,
 and breaking changes will not necessarily result in changes to the main version number.
 
-## [v1.3.25-alpha](https://github.com/Lexpedite/blawx/releases/tag/v1.3.25-alpha) 2022-08-9
+## [v1.3.26-alpha](https://github.com/Lexpedite/blawx/releases/tag/v1.3.26-alpha) 2022-08-10
+
+### Fixed
+* A bug where multiple users importing the same project caused code to disappear was fixed.
+
+## [v1.3.25-alpha](https://github.com/Lexpedite/blawx/releases/tag/v1.3.25-alpha) 2022-08-09
 
 ### Fixed
 * A bug where non-admin users did not have permissions to export projects was fixed.

--- a/blawx/views.py
+++ b/blawx/views.py
@@ -129,6 +129,7 @@ def ruleDocImportView(request):
             
             # Use the PK of the saved version to save the workspaces and tests
             for o in new_object_list[1:]:
+                o.object.pk = None
                 o.object.ruledoc = new_object_list[0].object
                 o.object.save()
             # Now trigger the post-save for the RuleDoc object to set permissions on sub-objects.
@@ -155,6 +156,7 @@ def exampleLoadView(request,example_name):
         new_object_list[0].object.save()
         # Use the PK of the saved version to save the workspaces and tests
         for o in new_object_list[1:]:
+            o.object.pk = None
             o.object.ruledoc = new_object_list[0].object
             o.object.save()
         # Now trigger the post-save for the RuleDoc object to set permissions on sub-objects.

--- a/newblawx/settings.py
+++ b/newblawx/settings.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 from pathlib import Path
 
 # For adding a version identifier
-BLAWX_VERSION = "v1.3.25-alpha"
+BLAWX_VERSION = "v1.3.26-alpha"
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
Solves a problem where uploading the same project (or importing the same example) by multiple users was causing earlier instances of the project to lose their saved code.