### PR TITLE
correct two errors in covid code

### DIFF
--- a/blawx/static/blawx/examples/covid_test.yaml
+++ b/blawx/static/blawx/examples/covid_test.yaml
@@ -1,5 +1,5 @@
 - model: blawx.ruledoc
-  pk: 15
+  pk: 5
   fields:
     ruledoc_name: Covid Test
     rule_text: "Covid Test Rule\r\n\r\n1. A person may board a flight if they have
@@ -10,16 +10,16 @@
     owner: 3
     published: false
 - model: blawx.workspace
-  pk: 2
+  pk: 33
   fields:
-    ruledoc: 2
+    ruledoc: 5
     workspace_name: root_section
     xml_content: ''
     scasp_encoding: ''
 - model: blawx.workspace
-  pk: 3
+  pk: 34
   fields:
-    ruledoc: 2
+    ruledoc: 5
     workspace_name: sec_1_section
     xml_content: <xml xmlns="https://developers.google.com/blockly/xml"><block type="unattributed_fact"
       id="/VkgyzyW3Xot[^le+r(Z" x="47" y="53"><statement name="statements"><block
@@ -89,8 +89,7 @@
       type="object_declaration" id="LIJG^YMKpXl#JVFTe+g2"><mutation xmlns="http://www.w3.org/1999/xhtml"
       category_name="test_result" prefix="null" postfix="null"></mutation><field name="prefix"></field><field
       name="object_name">negative</field><field name="postfix">is a test_result</field></block></next></block></next></block></next></block></next></block></next></block></next></block></next></block></next></block></statement></block><block
-      type="unattributed_rule" id="0/5;}|:)UO@W??KKFuYt" x="45" y="611"></block><block
-      type="unattributed_rule" id="aLoY$}g)e~Lk6[CPP;zy" x="45" y="968"><statement
+      type="unattributed_rule" id="aLoY$}g)e~Lk6[CPP;zy" x="51" y="946"><statement
       name="conditions"><block type="object_category" id="K9D7uGA,H-6q1RY_:Cwr"><value
       name="object"><block type="variable" id="y-]ckU*=JTsEmFw:%:-!"><field name="variable_name">Person</field></block></value><value
       name="category"><block type="category_selector" id="#uXgDAae-;:udkd$X:Gr"><mutation
@@ -137,8 +136,8 @@
       name="variable_name">Test</field></block></value><value name="second_element"><block
       type="variable" id="/{=Ag/-4@aZR=3f/XN|v"><field name="variable_name">TestTime</field></block></value><next><block
       type="date_difference" id="BM7Nwc;=nYK/m`BTFeO,"><value name="first_date"><block
-      type="variable" id=".cPj^#I60%q94zq#.`{n"><field name="variable_name">TestTime</field></block></value><value
-      name="second_date"><block type="variable" id="S@50mUR[Dxc}OWtpma=m"><field name="variable_name">ScheduledDeparture</field></block></value><value
+      type="variable" id="S@50mUR[Dxc}OWtpma=m"><field name="variable_name">ScheduledDeparture</field></block></value><value
+      name="second_date"><block type="variable" id=".cPj^#I60%q94zq#.`{n"><field name="variable_name">TestTime</field></block></value><value
       name="duration"><block type="variable" id="^BKVBF}*RG]k#6ePCDTU"><field name="variable_name">DurationFromTestToDeparture</field></block></value><next><block
       type="duration_comparison" id="2JX+jV=xh`c5A?G7I|vl"><field name="comparison">lte</field><value
       name="first_date"><block type="variable" id="RoC%ix41E*W#`J[hT]LQ"><field name="variable_name">DurationFromTestToDeparture</field></block></value><value
@@ -153,47 +152,146 @@
       type="variable" id="Hv_vcEVTe$YiS~6$6H7I"><field name="variable_name">Person</field></block></value><value
       name="second_element"><block type="variable" id="^Su_hE%A/=dWzYkGu1Xv"><field
       name="variable_name">Flight</field></block></value></block></statement></block></xml>
-    scasp_encoding: "blawx_category(person).\n#pred person(X) :: '@(X) is a person'.\n#pred
-      according_to(R,person(X)) :: 'according to @(R), @(X) is a person'.\n#pred legally_holds(_,person(X))
-      :: 'it legally holds that @(X) is a person'.\nblawx_category(flight).\n#pred
-      flight(X) :: '@(X) is a flight'.\n#pred according_to(R,flight(X)) :: 'according
-      to @(R), @(X) is a flight'.\n#pred legally_holds(_,flight(X)) :: 'it legally
-      holds that @(X) is a flight'.\nblawx_category(test_result).\n#pred test_result(X)
-      :: '@(X) is a test_result'.\n#pred according_to(R,test_result(X)) :: 'according
-      to @(R), @(X) is a test_result'.\n#pred legally_holds(_,test_result(X)) :: 'it
-      legally holds that @(X) is a test_result'.\nblawx_category(test).\n#pred test(X)
-      :: '@(X) is a test'.\n#pred according_to(R,test(X)) :: 'according to @(R), @(X)
-      is a test'.\n#pred legally_holds(_,test(X)) :: 'it legally holds that @(X) is
-      a test'.\nblawx_attribute(person,ticketed_for,flight).\nblawx_attribute_nlg(ticketed_for,ov,\"\",\"has
-      a ticket for\",\"\").\n#pred ticketed_for(X,Y) :: '@(X) has a ticket for @(Y)'.\n#pred
-      according_to(R,ticketed_for(X,Y)) :: 'according to @(R), @(X) has a ticket for
-      @(Y)'.\n#pred legally_holds(_,ticketed_for(X,Y)) :: 'it legally holds that @(X)
-      has a ticket for @(Y)'.\n\nblawx_attribute(person,may_board,flight).\nblawx_attribute_nlg(may_board,ov,\"\",\"is
-      permitted to board\",\"\").\n#pred may_board(X,Y) :: '@(X) is permitted to board
-      @(Y)'.\n#pred according_to(R,may_board(X,Y)) :: 'according to @(R), @(X) is
-      permitted to board @(Y)'.\n#pred legally_holds(_,may_board(X,Y)) :: 'it legally
-      holds that @(X) is permitted to board @(Y)'.\n\nblawx_attribute(test,subject,person).\nblawx_attribute_nlg(subject,vo,\"\",\"took
-      a covid test\",\"\").\n#pred subject(Y,X) :: '@(X) took a covid test @(Y)'.\n#pred
-      according_to(R,subject(Y,X)) :: 'according to @(R), @(X) took a covid test @(Y)'.\n#pred
-      legally_holds(_,subject(Y,X)) :: 'it legally holds that @(X) took a covid test
-      @(Y)'.\n\nblawx_attribute(test,result,test_result).\nblawx_attribute_nlg(result,ov,\"the
-      result of\",\"was\",\"\").\n#pred result(X,Y) :: 'the result of @(X) was @(Y)'.\n#pred
-      according_to(R,result(X,Y)) :: 'according to @(R), the result of @(X) was @(Y)'.\n#pred
-      legally_holds(_,result(X,Y)) :: 'it legally holds that the result of @(X) was
-      @(Y)'.\n\nblawx_attribute(test,administered_at,datetime).\nblawx_attribute_nlg(administered_at,ov,\"\",\"was
-      administered at\",\"\").\n#pred administered_at(X,Y) :: '@(X) was administered
-      at @(Y)'.\n#pred according_to(R,administered_at(X,Y)) :: 'according to @(R),
-      @(X) was administered at @(Y)'.\n#pred legally_holds(_,administered_at(X,Y))
-      :: 'it legally holds that @(X) was administered at @(Y)'.\n\nblawx_attribute(flight,scheduled_departure,datetime).\nblawx_attribute_nlg(scheduled_departure,ov,\"\",\"is
-      scheduled to depart at\",\"\").\n#pred scheduled_departure(X,Y) :: '@(X) is
-      scheduled to depart at @(Y)'.\n#pred according_to(R,scheduled_departure(X,Y))
-      :: 'according to @(R), @(X) is scheduled to depart at @(Y)'.\n#pred legally_holds(_,scheduled_departure(X,Y))
-      :: 'it legally holds that @(X) is scheduled to depart at @(Y)'.\n\ntest_result(positive).\ntest_result(negative).\n\n
-      :-\n.\n\nmay_board(Person,Flight) :-\nperson(Person),\nflight(Flight),\ntest(Test),\nticketed_for(Person,Flight),\nsubject(Test,Person),\nscheduled_departure(Flight,ScheduledDeparture),\nresult(Test,negative),\nadministered_at(Test,TestTime),\ndatetime_diff_duration(TestTime,ScheduledDeparture,DurationFromTestToDeparture),\nlte(DurationFromTestToDeparture,duration(1,0,0,0,72,0,0))."
+    scasp_encoding: 'blawx_category(person).
+
+      #pred person(X) :: ''@(X) is a person''.
+
+      #pred according_to(R,person(X)) :: ''according to @(R), @(X) is a person''.
+
+      #pred legally_holds(_,person(X)) :: ''it legally holds that @(X) is a person''.
+
+      blawx_category(flight).
+
+      #pred flight(X) :: ''@(X) is a flight''.
+
+      #pred according_to(R,flight(X)) :: ''according to @(R), @(X) is a flight''.
+
+      #pred legally_holds(_,flight(X)) :: ''it legally holds that @(X) is a flight''.
+
+      blawx_category(test_result).
+
+      #pred test_result(X) :: ''@(X) is a test_result''.
+
+      #pred according_to(R,test_result(X)) :: ''according to @(R), @(X) is a test_result''.
+
+      #pred legally_holds(_,test_result(X)) :: ''it legally holds that @(X) is a test_result''.
+
+      blawx_category(test).
+
+      #pred test(X) :: ''@(X) is a test''.
+
+      #pred according_to(R,test(X)) :: ''according to @(R), @(X) is a test''.
+
+      #pred legally_holds(_,test(X)) :: ''it legally holds that @(X) is a test''.
+
+      blawx_attribute(person,ticketed_for,flight).
+
+      blawx_attribute_nlg(ticketed_for,ov,"","has a ticket for","").
+
+      #pred ticketed_for(X,Y) :: ''@(X) has a ticket for @(Y)''.
+
+      #pred according_to(R,ticketed_for(X,Y)) :: ''according to @(R), @(X) has a ticket
+      for @(Y)''.
+
+      #pred legally_holds(_,ticketed_for(X,Y)) :: ''it legally holds that @(X) has
+      a ticket for @(Y)''.
+
+
+      blawx_attribute(person,may_board,flight).
+
+      blawx_attribute_nlg(may_board,ov,"","is permitted to board","").
+
+      #pred may_board(X,Y) :: ''@(X) is permitted to board @(Y)''.
+
+      #pred according_to(R,may_board(X,Y)) :: ''according to @(R), @(X) is permitted
+      to board @(Y)''.
+
+      #pred legally_holds(_,may_board(X,Y)) :: ''it legally holds that @(X) is permitted
+      to board @(Y)''.
+
+
+      blawx_attribute(test,subject,person).
+
+      blawx_attribute_nlg(subject,vo,"","took a covid test","").
+
+      #pred subject(Y,X) :: ''@(X) took a covid test @(Y)''.
+
+      #pred according_to(R,subject(Y,X)) :: ''according to @(R), @(X) took a covid
+      test @(Y)''.
+
+      #pred legally_holds(_,subject(Y,X)) :: ''it legally holds that @(X) took a covid
+      test @(Y)''.
+
+
+      blawx_attribute(test,result,test_result).
+
+      blawx_attribute_nlg(result,ov,"the result of","was","").
+
+      #pred result(X,Y) :: ''the result of @(X) was @(Y)''.
+
+      #pred according_to(R,result(X,Y)) :: ''according to @(R), the result of @(X)
+      was @(Y)''.
+
+      #pred legally_holds(_,result(X,Y)) :: ''it legally holds that the result of
+      @(X) was @(Y)''.
+
+
+      blawx_attribute(test,administered_at,datetime).
+
+      blawx_attribute_nlg(administered_at,ov,"","was administered at","").
+
+      #pred administered_at(X,Y) :: ''@(X) was administered at @(Y)''.
+
+      #pred according_to(R,administered_at(X,Y)) :: ''according to @(R), @(X) was
+      administered at @(Y)''.
+
+      #pred legally_holds(_,administered_at(X,Y)) :: ''it legally holds that @(X)
+      was administered at @(Y)''.
+
+
+      blawx_attribute(flight,scheduled_departure,datetime).
+
+      blawx_attribute_nlg(scheduled_departure,ov,"","is scheduled to depart at","").
+
+      #pred scheduled_departure(X,Y) :: ''@(X) is scheduled to depart at @(Y)''.
+
+      #pred according_to(R,scheduled_departure(X,Y)) :: ''according to @(R), @(X)
+      is scheduled to depart at @(Y)''.
+
+      #pred legally_holds(_,scheduled_departure(X,Y)) :: ''it legally holds that @(X)
+      is scheduled to depart at @(Y)''.
+
+
+      test_result(positive).
+
+      test_result(negative).
+
+
+      may_board(Person,Flight) :-
+
+      person(Person),
+
+      flight(Flight),
+
+      test(Test),
+
+      ticketed_for(Person,Flight),
+
+      subject(Test,Person),
+
+      scheduled_departure(Flight,ScheduledDeparture),
+
+      result(Test,negative),
+
+      administered_at(Test,TestTime),
+
+      datetime_diff_duration(ScheduledDeparture,TestTime,DurationFromTestToDeparture),
+
+      lte(DurationFromTestToDeparture,duration(1,0,0,0,72,0,0)).'
 - model: blawx.blawxtest
-  pk: 12
+  pk: 37
   fields:
-    ruledoc: 2
+    ruledoc: 5
     test_name: can_fly
     xml_content: <xml xmlns="https://developers.google.com/blockly/xml"><block type="query"
       id="U*RvlVr.!T)x:88LbXnM" x="90" y="249"><comment pinned="false" h="146" w="524">This
@@ -208,10 +306,11 @@
 
       ?- may_board(Person,Flight).'
     tutorial: ''
+    view: '[''view_cat_test_result'']'
 - model: blawx.blawxtest
-  pk: 13
+  pk: 38
   fields:
-    ruledoc: 2
+    ruledoc: 5
     test_name: good_test
     xml_content: <xml xmlns="https://developers.google.com/blockly/xml"><block type="unattributed_fact"
       id="~6[h`_zeg/KMr3bFg1H8" x="68" y="49"><statement name="statements"><block
@@ -294,10 +393,11 @@
 
       ?- may_board(bob,flight_to_hawaii).'
     tutorial: ''
+    view: ''
 - model: blawx.blawxtest
-  pk: 14
+  pk: 39
   fields:
-    ruledoc: 2
+    ruledoc: 5
     test_name: old_test
     xml_content: <xml xmlns="https://developers.google.com/blockly/xml"><block type="unattributed_fact"
       id="zC:]x}y1*:_,v-w1e;sv" x="111" y="89"><statement name="statements"><block
@@ -380,3 +480,4 @@
 
       ?- may_board(bob,flight_to_hawaii).'
     tutorial: ''
+    view: ''


### PR DESCRIPTION
this corrects two small errors in the covid example added in 1.3.33, and applies the scenario editor features from 1.3.34 to that example.