### PR TITLE
Fix Install Issue with aiohttp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ As of v0.2-alpha, this project is attempting to adhere to [Semantic Versioning](
 While alpha, however, any version may include breaking changes that may not be specifically noted as such,
 and breaking changes will not necessarily result in changes to the main version number.
 
+## [v1.6.22-alpha](https://github.com/Lexpedite/blawx/releases/tag/v1.6.22-alpha) 2023-10-18
+
+### Fixes
+* Fresh installs were failing due to dependency issues.
+
 ## [v1.6.21-alpha](https://github.com/Lexpedite/blawx/releases/tag/v1.6.21-alpha) 2023-09-21
 
 ### Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM swipl:latest as prolog
 
 FROM python:latest
 
+
 ENV DEBIAN_FRONTEND=noninteractive
+
+RUN pip install --upgrade pip
 
 RUN apt-get -y update
 

--- a/blawx/requirements.txt
+++ b/blawx/requirements.txt
@@ -7,4 +7,5 @@ clean-law >=0.0.4
 django-guardian
 django-preferences
 django-cors-headers
+aiohttp >= 3.9.0b0
 openai

--- a/blawx/settings.py
+++ b/blawx/settings.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 from pathlib import Path
 
 # For adding a version identifier
-BLAWX_VERSION = "v1.6.21-alpha"
+BLAWX_VERSION = "v1.6.22-alpha"
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.


### PR DESCRIPTION
This change should be temporary, and the additional line in requirements.txt should be removed when the stable version of aiohttp installs properly in Python 3.12.