### PR TITLE
fix blockly version to avoid deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,11 @@ RUN mkdir blawx/blawx/static/blawx/fonts
 
 # RUN git clone https://github.com/google/blockly --branch develop blawx/blawx/static/blawx/blockly 
 
-RUN npm install blockly
+# NOTE: currently Blawx blocks works only blockly < 11.0
+# update to the latest version after the deprecation warning below is resolved
+#
+# block generator functions on CodeGenerator objects was deprecated in 10.0 and will be deleted in 11.0. Use the .forBlock[blockType] dictionary instead.
+RUN npm install blockly@10.1.3
 
 RUN mv ./node_modules/blockly /app/blawx/blawx/static/blawx
 


### PR DESCRIPTION
This PR fixes the blockly version to fix errors that occur when moving blocks.

Currently, when using containers built by Dockerfile, blocks cannot be selected and an error below is raised.

```
 Uncaught Error: sCASP generator does not know how to generate code for block type "unattributed_fact".
     at Object.blockToCode (generator.ts:259:13)
     at Object.workspaceToCode (generator.ts:159:23)
     at liveCode (blawx2scasp.js:3:20)
     at WorkspaceSvg$$module$build$src$core$workspace_svg.fireChangeListener (workspace.ts:704:7)
     at fireNow$$module$build$src$core$events$utils (utils.ts:131:49)
```

This is because installed `blockly` version is too new to run the block generator functions used in Blawx.

This PR fixes the installed blockly version to use the same version as the current tag of the official Docker image `lexpedite/blawx:latest`.