### PR TITLE
add regex validator for project test name

### DIFF
--- a/blawx/models.py
+++ b/blawx/models.py
@@ -2,6 +2,7 @@ from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.db import models
 from django.contrib.auth.models import User
+from django.core.validators import RegexValidator
 from .parse_an import generate_tree
 from cobalt.hierarchical import Act
 from clean.clean import generate_akn
@@ -54,7 +55,8 @@ class Workspace(models.Model):
 
 class BlawxTest(models.Model):
     ruledoc = models.ForeignKey(RuleDoc, related_name='tests', on_delete=models.CASCADE)
-    test_name = models.CharField(max_length=200)
+    validate_test_name = RegexValidator(regex="^[-a-zA-Z0-9_]+$",message="Test names cannot have spaces or special characters.")
+    test_name = models.CharField(max_length=200,validators=[validate_test_name])
     xml_content = models.TextField(default="",blank=True)
     scasp_encoding = models.TextField(default="",blank=True)
     tutorial = models.TextField(default="",blank=True)


### PR DESCRIPTION
This PR adds a test name validator to prevent project crashes.

Since test names cannot have special characters, creating a new test with a special character name causes an error.
Furthermore, once a test with an invalid name has been created in a project, every page in the project throws the same error and the project cannot be used anymore.

(before: creating a new test with a special character name)
![blawx_test1](https://github.com/user-attachments/assets/b3a4cd72-b747-4c0d-8627-e81d3efba84d)

(before: top page in the project throws an error)
![blawx_test2](https://github.com/user-attachments/assets/d3398a5f-dd15-4389-b0a9-f5231937617e)

```
NoReverseMatch at /user1/foobar/
Reverse for 'test' with arguments '(<User: user1>, 'foobar', 'test!')' not found. 1 pattern(s) tried: ['(?P<user>[^/]+)/(?P<rule>[-a-zA-Z0-9_]+)/test/(?P<test_name>[-a-zA-Z0-9_]+)/\\Z']
```

This PR adds a validator to the `BlawxTest` model to validate its name before saving it so that any other pages in the project can be accessed afterwards.

(after: a new test with a special character name is validated before saved)
![blawx_fixed](https://github.com/user-attachments/assets/8dc17e6b-915d-4cbd-860b-50708657364d)

(after: top page in the project can be accessed)
![image](https://github.com/user-attachments/assets/8e30e69d-b1eb-4bda-ba01-ebdd98e50ee4)
